### PR TITLE
Add support for specifying {offset, limit} for printjobs().

### DIFF
--- a/src/printnode-ws-http-client.js
+++ b/src/printnode-ws-http-client.js
@@ -1402,6 +1402,14 @@ var PrintNode = (function () {
             if (params.printjobSet) {
                 url += '/'+params.printjobSet.toString();
             }
+            if (params.range) {
+                if (params.range.limit !== undefined) {
+                    url += '?limit='+params.range.limit.toString();
+                }
+                if (params.range.offset !== undefined) {
+                    url += (params.range.limit !== undefined ? '&' : '?')+'offset='+params.range.offset.toString();
+                }
+            }
         }
         return ajax(this._makeReqOptions(options), 'GET', url);
     };


### PR DESCRIPTION
'params' parameter of printjobs(options, params) supports an additional, optional field, 'range' which is an object {offset: n, limit: m}, as per PrintNode docs.
